### PR TITLE
[getDomainsDNS.gs] Filter SPF TXT records to only display the v=spf1 line using regex

### DIFF
--- a/getDomainsDNS.gs
+++ b/getDomainsDNS.gs
@@ -244,6 +244,10 @@ function getDnsRecords(domainList) {
     Utilities.sleep(delayBetweenCalls);
 
     let spfRecords = performGoogleDNSLookup("TXT", domain);
+    // Use regex to extract the first line containing 'v=spf1' (case-insensitive)
+    if (spfRecords.data) {
+      spfRecords.data = (spfRecords.data.match(/^.*v=spf1.*$/gim) || ["No SPF record found"])[0];
+    }
     Utilities.sleep(delayBetweenCalls);
 
     let dkimRecords = performGoogleDNSLookup("TXT", "google._domainkey." + domain);

--- a/getDomainsDNS.gs
+++ b/getDomainsDNS.gs
@@ -30,7 +30,7 @@ function getDomainList() {
       .setBackground("#fc3165")
       .setFontWeight("bold");
     sheet.getRange("D1").setNote("Mail Exchange, Green cells indicate Google MX records were found.");
-    sheet.getRange("E1").setNote("Sender Policy Framework, Green cells indicate Google SPF record was found.");
+    sheet.getRange("E1").setNote("Sender Policy Framework, Green cells indicate Google SPF record was found. Red cells indicate multiple SPF records were found, or no records found.");
     sheet.getRange("F1").setNote("DomainKeys Identified Mail, Green cells indicate the default DKIM selector for Google was found.");
     sheet.getRange("G1").setNote("Domain-based Message Authentication, Reporting, and Conformance, Green cells indicate DMARC records were found.");
     sheet.getRange("H1").setNote("Status of DNS Lookups");
@@ -120,6 +120,16 @@ function getDomainList() {
 
     // Apply conditional formatting rules
     const rules = [];
+
+    // Rule for multiple SPF records
+    const spfColumnRange = sheet.getRange(`E2:E${lastRow}`);
+    const multipleSpfRule = SpreadsheetApp.newConditionalFormatRule()
+      .whenFormulaSatisfied('=ISNUMBER(SEARCH("Warning: Multiple SPF records found", H2))')
+      .setBackground("#ffb6c1")
+      .setRanges([spfColumnRange])
+      .build();
+    rules.push(multipleSpfRule);
+
     const ranges = {
         D: "google",
         E: "_spf.google.com",
@@ -145,6 +155,7 @@ function getDomainList() {
 
         rules.push(greenRule, redRule);
     }
+
     sheet.setConditionalFormatRules(rules);
 
     // --- Add Filter View ---

--- a/getDomainsDNS.gs
+++ b/getDomainsDNS.gs
@@ -254,7 +254,21 @@ function getDnsRecords(domainList) {
 
 
     mxRecords.data = mxRecords.data || "No MX records found";
-    spfRecords.data = ((spfRecords.data || "").match(/^.*v=spf1.*$/gim) || ["No SPF record found"])[0];
+
+    // Filter for SPF records and handle multiple policies.
+    const spfPolicies = (spfRecords.data || "").match(/^.*v=spf1.*$/gim);
+    if (!spfPolicies) {
+      spfRecords.data = "No SPF record found";
+    } else {
+      if (spfPolicies.length > 1) {
+        // If multiple SPF records are found, append a warning to the status.
+        // This is a configuration error that admins should be aware of.
+        spfRecords.status += "; Warning: Multiple SPF records found";
+      }
+      // Join all found SPF records, separated by a newline.
+      spfRecords.data = spfPolicies.join('\n');
+    }
+
     dkimRecords.data = dkimRecords.data || "No DKIM records found";
     dmarcRecords.data = dmarcRecords.data || "No DMARC records found";
 

--- a/getDomainsDNS.gs
+++ b/getDomainsDNS.gs
@@ -244,10 +244,6 @@ function getDnsRecords(domainList) {
     Utilities.sleep(delayBetweenCalls);
 
     let spfRecords = performGoogleDNSLookup("TXT", domain);
-    // Use regex to extract the first line containing 'v=spf1' (case-insensitive)
-    if (spfRecords.data) {
-      spfRecords.data = (spfRecords.data.match(/^.*v=spf1.*$/gim) || ["No SPF record found"])[0];
-    }
     Utilities.sleep(delayBetweenCalls);
 
     let dkimRecords = performGoogleDNSLookup("TXT", "google._domainkey." + domain);
@@ -258,7 +254,7 @@ function getDnsRecords(domainList) {
 
 
     mxRecords.data = mxRecords.data || "No MX records found";
-    spfRecords.data = spfRecords.data || "No SPF records found";
+    spfRecords.data = ((spfRecords.data || "").match(/^.*v=spf1.*$/gim) || ["No SPF record found"])[0];
     dkimRecords.data = dkimRecords.data || "No DKIM records found";
     dmarcRecords.data = dmarcRecords.data || "No DMARC records found";
 


### PR DESCRIPTION
Hi there! This PR improves the accuracy and clarity of the SPF record extraction in the Domains/DNS inventory script. Previously, the SPF column could include all TXT records for a domain, resulting in cluttered output with unrelated verification and service records. Now, only the actual SPF policy line (starting with v=spf1) is displayed, making the report more useful and easier to understand.

The logic for MX, DKIM, and DMARC records remains unchanged.

Example (TXT lookup for netsec[.]it)

**Before:**
```txt
MS=ms11543810
google-site-verification=KZaaM7LE8rtso0RqbBYiIZe8iOptp3lUlmOdiBoaybU
google-site-verification=vxHp2RuECOIirbYEHH2m-ODDx5wTCzdvKky4u4TZdu8
v=spf1 include:_spf.google.com include:spf.protection.outlook.com ~all
slack-domain-verification=xxfYWIsj1LGTLnogvPEKFzFMAh8aNRhTziMUDMIU
```

**After:**
```txt
v=spf1 include:_spf.google.com include:spf.protection.outlook.com ~all
```